### PR TITLE
Add a background color to the room name in person view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,8 +58,6 @@ const App = () => {
     setOnline(false);
   };
 
-  console.log(61, online);
-
   useEffect(() => {
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);

--- a/src/pages/Competition/Competitors/index.tsx
+++ b/src/pages/Competition/Competitors/index.tsx
@@ -10,8 +10,6 @@ export default function Competitors({ wcif }) {
 
   const me = acceptedPersons.find((person) => person.wcaUserId === user?.id);
 
-  console.log(acceptedPersons);
-
   return (
     <div className="w-full h-full flex flex-1 flex-col p-2">
       {me && (

--- a/src/pages/Competition/GroupsOverview.tsx
+++ b/src/pages/Competition/GroupsOverview.tsx
@@ -63,7 +63,6 @@ const GroupsOverview = () => {
       .sort((a, b) => a.name.localeCompare(b.name))
       .map((person) => {
         const a = assignmentsToObj(person);
-        console.log(person, a);
         return { ...person, assignmentsData: a };
       });
   }, [assignmentsToObj, wcif.persons]);

--- a/src/pages/Competition/Person/index.tsx
+++ b/src/pages/Competition/Person/index.tsx
@@ -1,6 +1,8 @@
 import { hasFlag } from 'country-flag-icons';
 import getUnicodeFlagIcon from 'country-flag-icons/unicode';
-import { useCallback, useEffect, useMemo } from 'react';
+import tw from 'tailwind-styled-components';
+import styled from 'styled-components';
+import { useCallback, useEffect, useMemo, Fragment } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useWCIF } from '../WCIFProvider';
 import { allActivities, parseActivityCode } from '../../../lib/activities';
@@ -16,6 +18,17 @@ export const byDate = (
   const bDate = b ? new Date(b.startTime).getTime() : Number.MAX_SAFE_INTEGER;
   return aDate - bDate;
 };
+
+
+const RoundedBg = tw.span`
+  px-[6px]
+  py-[4px]
+  rounded-md
+`;
+
+const RoomColored = styled(RoundedBg)`
+  background-color: ${p => p.$color ? `${p.$color}70` : 'inherit'};
+`;
 
 export default function Person() {
   const { wcif, setTitle } = useWCIF();
@@ -102,7 +115,7 @@ export default function Person() {
           </thead>
           <tbody>
             {scheduleDays.map(({ date, dateParts }) => (
-              <>
+              <Fragment key={date}>
                 <tr>
                   <td colSpan={6} className="font-bold text-lg text-center py-2">
                     {dateParts.find((i) => i.type === 'weekday')?.value || date}
@@ -122,6 +135,7 @@ export default function Person() {
                     const timeZone = venue?.timezone;
 
                     const roomName = activity?.room?.name || activity?.parent?.room?.name;
+                    const roomColor = activity?.room?.color || activity?.parent?.room?.color;
                     const startTime = roundTime(
                       new Date(activity?.startTime || 0),
                       5
@@ -142,7 +156,9 @@ export default function Person() {
                         </td>
                         <td className="py-2 text-center">{roundNumber}</td>
                         <td className="py-2 text-center">{groupNumber || '*'}</td>
-                        <td className="py-2 text-center">{roomName}</td>
+                        <td className="py-2 text-center">
+                          <RoomColored $color={roomColor}>{roomName}</RoomColored>
+                        </td>
                         <td className="py-2 text-center">
                           <AssignmentLabel assignmentCode={assignment.assignmentCode} />
                         </td>
@@ -152,7 +168,7 @@ export default function Person() {
                       </Link>
                     );
                   })}
-              </>
+              </Fragment>
             ))}
           </tbody>
         </table>

--- a/src/pages/Competition/WCIFProvider.tsx
+++ b/src/pages/Competition/WCIFProvider.tsx
@@ -72,8 +72,6 @@ export default function WCIFProvider({ competitionId, children }) {
     </div>;
   }
 
-  console.log(97, wcif);
-
   return (
     <WCIFContext.Provider value={{ wcif: wcif as Competition, setTitle }}>
       {!online && (


### PR DESCRIPTION
We generally use "room" as a way to represent "stages", and it would actually help a lot the competitors to immediately know which stage they are on by looking at the color.

I'm not sure if that's something you would be interested in having in competitor groups, but in any case here is a PR with what I could do locally and that we would love to have for our upcoming nationals!

Here is a screenshot of a personal schedule illustrating the changes:
![color](https://user-images.githubusercontent.com/1007485/234046772-59560224-a464-436d-8d5f-ddcf5edc215a.png)

I also included a commit removing the remaining `console.log` which flood a bit the console (I can definitely remove the commit if you would like to keep them).