### PR TITLE
Always use English names for activities

### DIFF
--- a/src/components/ActivitiyRow.tsx
+++ b/src/components/ActivitiyRow.tsx
@@ -1,5 +1,5 @@
 import { Link, useParams } from 'react-router-dom';
-import { Activity, Room, Venue } from '@wca/helpers';
+import { Activity, Room, Venue, activityCodeToName } from '@wca/helpers';
 import { formatTimeRange } from '../lib/time';
 import classNames from 'classnames';
 import { useNow } from '../hooks/useNow';
@@ -22,6 +22,7 @@ export default function ActivityRow({
   const now = useNow();
 
   const isOver = useMemo(() => new Date(activity.endTime).getTime() < now.getTime(), []);
+  const activityName = activity.activityCode.startsWith('other') ? activity.name : activityCodeToName(activity.activityCode);
 
   return (
     <Link
@@ -33,7 +34,7 @@ export default function ActivityRow({
         }
       )}
       to={`/competitions/${competitionId}/activities/${activity.id}`}>
-      <span>{activity.name}</span>
+      <span>{activityName}</span>
       <span className="text-xs md:text-sm font-light flex justify-between">
         {showRoom && (
           <span


### PR DESCRIPTION
While viewing the Euro schedule, I noticed that some rounds are named in Spanish, while others are in English (see https://github.com/thewca/worldcubeassociation.org/issues/9366). After my changes, activities whose code starts with `other` use their names from the schedule, while round names are computed from their `activityCode`.

Before:
![image](https://github.com/user-attachments/assets/a1f09c09-f0e7-4356-9b28-d38398e8378f)

After:
![image](https://github.com/user-attachments/assets/2b7f59a5-e531-4b85-bfb9-321ffe8af5a0)
