### PR TITLE
Fix displaying stage leads on people list

### DIFF
--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -192,6 +192,7 @@ export const AssignmentCodeTitles = {
   'staff-dataentry': 'Data Entry',
   'staff-showrunner': 'Show Runners',
   'staff-announcer': 'Announcers',
+  'staff-stagelead': 'Stage Leads',
   'staff-delegate': 'Delegates',
   'staff-core': 'Core Staff',
   'staff-break': 'Break',

--- a/src/pages/Competition/Schedule/PeopleList.tsx
+++ b/src/pages/Competition/Schedule/PeopleList.tsx
@@ -39,6 +39,7 @@ export const PeopleList = ({
             'bg-blue-200': assignmentCode.match(/judge/i),
             'bg-cyan-200': assignmentCode === 'staff-dataentry',
             'bg-violet-200': assignmentCode === 'staff-announcer',
+            'bg-purple-800': assignmentCode === 'staff-stagelead',
             'bg-purple-200': assignmentCode === 'staff-delegate',
             'bg-slate-200': !AssignmentCodeRank.includes(assignmentCode),
             'bg-rose-200': assignmentCode === 'staff-core',
@@ -49,7 +50,7 @@ export const PeopleList = ({
             'even:bg-blue-50': assignmentCode.match(/judge/i),
             'even:bg-cyan-50': assignmentCode === 'staff-dataentry',
             'even:bg-violet-50': assignmentCode === 'staff-announcer',
-            'even:bg-purple-50': assignmentCode === 'staff-delegate',
+            'even:bg-purple-50': assignmentCode === 'staff-stagelead' || assignmentCode === 'staff-delegate',
             'even:bg-slate-50': !AssignmentCodeRank.includes(assignmentCode),
             'even:bg-rose-50': assignmentCode === 'staff-core',
           };


### PR DESCRIPTION
Hi,
while fiddling with wcif for Polish Nats I noticed that Competition Groups doesn't properly show team leads on people list despite code suggesting that it supports `staff-stagelead` role. This is how it looks now:
<img width="902" alt="Zrzut ekranu 2024-11-5 o 03 25 12" src="https://github.com/user-attachments/assets/abfbf523-d275-4fbe-891c-9dee9e6b14da">
And below how it should look after applying this PR:
<img width="879" alt="Zrzut ekranu 2024-11-5 o 03 26 21" src="https://github.com/user-attachments/assets/f40c9963-1171-4554-a5a8-5ed6e1237958">
Not exactly my favourite pick of color, but it is consistent with how badge look on personal schedule page.