### PR TITLE
Ignore accents and diacritics in person search

### DIFF
--- a/src/containers/Competitors/Competitors.tsx
+++ b/src/containers/Competitors/Competitors.tsx
@@ -44,7 +44,7 @@ export const Competitors = ({ wcif }: { wcif: Competition }) => {
 
   const acceptedUnpinnedPersons = everyoneButMe.filter(
     (person) =>
-      !person.pinned && (!input || person.name.toLowerCase().includes(input.toLowerCase().trim())),
+      !person.pinned && (!input || person.name.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "").includes(input.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "").trim())),
   );
 
   return (

--- a/src/containers/Competitors/Competitors.tsx
+++ b/src/containers/Competitors/Competitors.tsx
@@ -44,7 +44,19 @@ export const Competitors = ({ wcif }: { wcif: Competition }) => {
 
   const acceptedUnpinnedPersons = everyoneButMe.filter(
     (person) =>
-      !person.pinned && (!input || person.name.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "").includes(input.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "").trim())),
+      !person.pinned &&
+      (!input ||
+        person.name
+          .toLowerCase()
+          .normalize('NFD')
+          .replace(/[\u0300-\u036f]/g, '')
+          .includes(
+            input
+              .toLowerCase()
+              .normalize('NFD')
+              .replace(/[\u0300-\u036f]/g, '')
+              .trim(),
+          )),
   );
 
   return (


### PR DESCRIPTION
This PR makes person searching diacritic-insensitive. Names containing accented or special characters (e.g. you can search `Alvaro` to search for `Álvaro` and vice versa). Characters that do not decompose via NFD (e.g. `ł`, `ø`, `ß`) are not yet normalized.