### PR TITLE
Rename rankings tab to Psych Scheet

### DIFF
--- a/src/layouts/CompetitionLayout/CompetitionLayout.tabs.tsx
+++ b/src/layouts/CompetitionLayout/CompetitionLayout.tabs.tsx
@@ -40,7 +40,7 @@ export const useCompetitionLayoutTabs = ({ competitionId, wcif }: CompetitionLay
       },
       {
         href: `/competitions/${competitionId}/psych-sheet`,
-        text: 'Rankings',
+        text: 'Psych Scheet',
       },
     );
 


### PR DESCRIPTION
## Summary
- rename the 'Rankings' tab text to `Psych Scheet`

## Testing
- `yarn lint`
- `yarn test` *(fails: Command "test" not found)*