### PR TITLE
Fix time limit rendering and miscellaneous improvements

### DIFF
--- a/src/components/AssignmentLabel/AssignmentLabel.tsx
+++ b/src/components/AssignmentLabel/AssignmentLabel.tsx
@@ -37,7 +37,7 @@ export function AssignmentLabel({ assignmentCode }: AssignmentLabelProps) {
     case 'staff-delegate':
       return <Pill className="bg-purple-200">{name}</Pill>;
     case 'staff-stagelead':
-      return <Pill className="bg-purple-800">{name}</Pill>;
+      return <Pill className="bg-fuchsia-200">{name}</Pill>;
     default:
       return <Pill className="bg-blue-100">{name}</Pill>;
   }

--- a/src/components/CutoffTimeLimitPanel/CutoffTimeLimitPanel.tsx
+++ b/src/components/CutoffTimeLimitPanel/CutoffTimeLimitPanel.tsx
@@ -42,34 +42,49 @@ export function CutoffTimeLimitPanel({
             </span>
           )}
 
-          {timeLimit && timeLimit?.cumulativeRoundIds.length > 0 && (
-            <div className="px-2">
-              <Trans
-                i18nKey={'common.wca.cumulativeTimelimit'}
-                values={{ time: timelimitTime }}
-                components={{ b: <span className="font-semibold" /> }}
-              />
-              {': '}
-              <span>
-                {timeLimit.cumulativeRoundIds
-                  .filter((activityCode) => activityCode !== round.id)
-                  .map((activityCode, i, arry) => {
-                    const { eventId, roundNumber } = parseActivityCode(activityCode);
-                    return (
-                      <Link
-                        key={activityCode}
-                        to={`/competitions/${wcif?.id}/events/${activityCode}`}>
-                        <span
-                          className={`cubing-icon event-${eventId} mx-1 before:-ml-1 before:mr-2`}>
-                          {t('common.activityCodeToName.round', { roundNumber })}
-                          {i < arry.length - 1 ? ', ' : ''}
-                        </span>
-                      </Link>
-                    );
-                  })}
+          {timeLimit &&
+            timeLimit?.cumulativeRoundIds.length > 0 &&
+            timeLimit.cumulativeRoundIds.filter((activityCode) => activityCode !== round.id)
+              .length === 0 && (
+              <span className="px-2">
+                <Trans
+                  i18nKey={'common.wca.cumulativeTimelimit'}
+                  values={{ time: timelimitTime }}
+                  components={{ b: <span className="font-semibold" /> }}
+                />
               </span>
-            </div>
-          )}
+            )}
+
+          {timeLimit &&
+            timeLimit?.cumulativeRoundIds.length > 0 &&
+            timeLimit.cumulativeRoundIds.filter((activityCode) => activityCode !== round.id)
+              .length > 0 && (
+              <div className="px-2">
+                <span>
+                  <Trans
+                    i18nKey={'common.wca.cumulativeTimelimitWithrounds'}
+                    values={{ time: timelimitTime }}
+                    components={{ b: <span className="font-semibold" /> }}
+                  />
+                  {timeLimit.cumulativeRoundIds
+                    .filter((activityCode) => activityCode !== round.id)
+                    .map((activityCode, i, arry) => {
+                      const { eventId, roundNumber } = parseActivityCode(activityCode);
+                      return (
+                        <Link
+                          key={activityCode}
+                          to={`/competitions/${wcif?.id}/events/${activityCode}`}>
+                          <span
+                            className={`cubing-icon event-${eventId} mx-1 before:-ml-1 before:mr-2`}>
+                            {t('common.activityCodeToName.round', { roundNumber })}
+                            {i < arry.length - 1 ? ', ' : ''}
+                          </span>
+                        </Link>
+                      );
+                    })}
+                </span>
+              </div>
+            )}
         </div>
         {round.advancementCondition && (
           <div>

--- a/src/i18n/en/translation.yaml
+++ b/src/i18n/en/translation.yaml
@@ -28,7 +28,8 @@ common:
       'other-mbld': 'MBLD Submission'
     timeLimit: 'Time Limit'
     cutoff: 'Cutoff'
-    cumulativeTimelimit: Time Limit <b>{{time}}</b> with rounds
+    cumulativeTimelimit: 'Time Limit: <b>{{time}} Cumulative</b>'
+    cumulativeTimelimitWithrounds: 'Time Limit: <b>{{time}} Total</b> with: '
     advancement:
       ranking: 'Top <b>{{level}}</b> to next round'
       percent: 'Top <b>{{level}}%</b> to next round'

--- a/src/i18n/ko/translation.yaml
+++ b/src/i18n/ko/translation.yaml
@@ -27,7 +27,8 @@ common:
       other-mbld: 멀티 블라인드 큐브 제출
     timeLimit: 기록 제한
     cutoff: 컷오프
-    cumulativeTimelimit: '누적 기록 제한: <b>{{time}}</b>'
+    cumulativeTimelimit: '기록 제한: <b>누적 {{time}}</b>'
+    cumulativeTimelimitWithrounds: '기록 제한: <b>총 {{time}}</b>, 대상 라운드: '
     advancement:
       ranking: 상위 <b>{{level}}</b>명이 다음 라운드로 진출
       percent: 상위 <b>{{level}}%</b>가 다음 라운드로 진출

--- a/src/i18n/ko/translation.yaml
+++ b/src/i18n/ko/translation.yaml
@@ -24,8 +24,10 @@ common:
       444bf: 4x4x4 블라인드
       555bf: 5x5x5 블라인드
       333mbf: 3x3x3 멀티 블라인드
+      other-mbld: 멀티 블라인드 큐브 제출
     timeLimit: 기록 제한
     cutoff: 컷오프
+    cumulativeTimelimit: '누적 기록 제한: <b>{{time}}</b>'
     advancement:
       ranking: 상위 <b>{{level}}</b>명이 다음 라운드로 진출
       percent: 상위 <b>{{level}}%</b>가 다음 라운드로 진출
@@ -101,10 +103,10 @@ common:
       noun_other: 사전 준비/행사 정리
       verb: 사전 준비 중/행사 정리 중
     staff-core:
-      noun: 핵심 스태프
-      noun_other: 핵심 스태프
-      verb: 핵심 스태프
-  lastFetched: '최근 가져오기: {{date}}'
+      noun: 코어 스태프
+      noun_other: 코어 스태프
+      verb: 코어 스태프
+  lastFetched: '최근 업데이트: {{date}}'
   competitionSelect:
     placeholder: 대회 검색
     noOptions: 검색된 대회 없음
@@ -136,6 +138,7 @@ home:
   yourCompetitions: 귀하의 대회
 competition:
   competitors:
+    viewMyAssignments: 나의 배정 보기
     viewCompetitionInformation: 대회 정보 보기
     searchCompetitors: 선수 검색
   groups:
@@ -156,11 +159,11 @@ competition:
     title: 순위
     name: 성명
   personalSchedule:
-    registeredEvents: 신청한 종목
+    registeredEvents: 신청된 종목
     viewPersonalRecords: 개인 기록 보기
     viewResults: 결과 보기
     noAssignments:
-      line1: 업무 없음
+      line1: 배정 없음
       line2: 나중에 다시 확인해 주세요!
     activity: 활동
     time: 시간
@@ -168,8 +171,9 @@ competition:
     group: 그룹
     stage: $t(common.stage)
     station: 스테이션
+    submitMultiCubes: MBLD 제출
   personalRecords:
-    viewSchedule: 개인 배정 업무 보기
+    viewSchedule: 개인 배정 보기
     type: 유형
     best: 최고 기록
   scramblers:
@@ -179,7 +183,7 @@ competition:
     event: 종목
     scramblers: 스크램블러
   streamSchedule:
-    title: 스트리밍 스케쥴
+    title: 스트리밍 일정
     subtitle: 생중계
     time: 시간
     event: $t(common.wca.event)

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -29,15 +29,17 @@ export const renderCutoff = (cutoff: Cutoff) => {
     return '-';
   }
 
-  return `${formatCentiseconds(cutoff.attemptResult).replace(/\.00+$/, '')}`;
+  return `${formatCentiseconds(cutoff.attemptResult)}`;
 };
 
 export const renderCentiseconds = (centiseconds: number) => {
-  if (centiseconds >= 60000) {
+  if (centiseconds >= 360000) {
     const hours = Math.floor(centiseconds / 360000);
-    const centi = formatCentiseconds(centiseconds - hours * 360000).replace(/\.00+$/, '');
-    return hours ? `${hours}:${centi}` : centi;
+    const minutes = Math.floor((centiseconds % 360000) / 6000);
+    const seconds = Math.floor((centiseconds % 6000) / 100);
+    const centis = centiseconds % 100;
+    return `${hours}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}.${centis.toString().padStart(2, '0')}`;
   }
 
-  return formatCentiseconds(centiseconds).replace(/\.00+$/, '');
+  return formatCentiseconds(centiseconds);
 };


### PR DESCRIPTION
Sorry for not separating changes into multiple branches.

Changes:
- Changed the color to a lighter tone (see #41)
- Fixed time limit rendering:
  - Cumulative time limits are now divided appropriately by the number of combination rounds
  - Format is now consistent with WCA standards (e.g. 1:30.00, 10:00.00 cumulative, 1:30:00.00 total for 5x5x5 Blindfolded First round and 4x4x4 Blindfolded First round)
- Updated Korean translations