### PR TITLE
[codex] Integrate NotifyComp assignment push

### DIFF
--- a/netlify/functions/notify-comp-token.js
+++ b/netlify/functions/notify-comp-token.js
@@ -1,0 +1,96 @@
+const crypto = require('crypto');
+
+const headers = {
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Origin': '*',
+  'Content-Type': 'application/json',
+};
+
+const base64Url = (value) => Buffer.from(value).toString('base64url');
+
+const signJwt = (claims, secret) => {
+  const encodedHeader = base64Url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const encodedPayload = base64Url(JSON.stringify(claims));
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(`${encodedHeader}.${encodedPayload}`)
+    .digest('base64url');
+
+  return `${encodedHeader}.${encodedPayload}.${signature}`;
+};
+
+exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      headers,
+      body: JSON.stringify({ message: 'Method not allowed' }),
+    };
+  }
+
+  const secret = process.env.COMPETITION_GROUPS_JWT_SECRET;
+  if (!secret) {
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({ message: 'Notification token secret is not configured' }),
+    };
+  }
+
+  const { accessToken } = JSON.parse(event.body || '{}');
+  if (!accessToken) {
+    return {
+      statusCode: 400,
+      headers,
+      body: JSON.stringify({ message: 'Missing WCA access token' }),
+    };
+  }
+
+  const wcaOrigin = process.env.WCA_ORIGIN || 'https://www.worldcubeassociation.org';
+  const meResponse = await fetch(`${wcaOrigin}/api/v0/me`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!meResponse.ok) {
+    return {
+      statusCode: 401,
+      headers,
+      body: JSON.stringify({ message: 'Invalid WCA access token' }),
+    };
+  }
+
+  const { me } = await meResponse.json();
+  if (!me?.id) {
+    return {
+      statusCode: 401,
+      headers,
+      body: JSON.stringify({ message: 'Unable to resolve WCA user' }),
+    };
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const token = signJwt(
+    {
+      aud: process.env.COMPETITION_GROUPS_JWT_AUDIENCE || 'notifycomp',
+      exp: now + 10 * 60,
+      iat: now,
+      iss: process.env.COMPETITION_GROUPS_JWT_ISSUER || 'competitiongroups.com',
+      sub: `wca:${me.id}`,
+      wcaUserIds: [me.id],
+    },
+    secret,
+  );
+
+  return {
+    statusCode: 200,
+    headers,
+    body: JSON.stringify({ token }),
+  };
+};

--- a/public/notification-sw.js
+++ b/public/notification-sw.js
@@ -1,0 +1,34 @@
+self.addEventListener('push', (event) => {
+  if (!event.data) {
+    return;
+  }
+
+  const payload = event.data.json();
+  const title = payload.title || 'Assignment update';
+  const options = {
+    body: payload.body,
+    data: payload,
+    tag: payload.dedupeKey || 'assignment-change',
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+
+  const targetUrl = event.notification.data?.url || '/settings';
+  const url = new URL(targetUrl, self.location.origin).href;
+
+  event.waitUntil(
+    self.clients.matchAll({ includeUncontrolled: true, type: 'window' }).then((clients) => {
+      const existingClient = clients.find((client) => client.url === url);
+
+      if (existingClient) {
+        return existingClient.focus();
+      }
+
+      return self.clients.openWindow(url);
+    }),
+  );
+});

--- a/src/apolloClient.ts
+++ b/src/apolloClient.ts
@@ -4,12 +4,12 @@ import { getMainDefinition } from '@apollo/client/utilities';
 import { createClient } from 'graphql-ws';
 
 const httpLink = createHttpLink({
-  uri: import.meta.env.VITE_NOTIFYCOMP_API_ORIGIN || 'https://admin.notifycomp.com/graphql',
+  uri: import.meta.env.VITE_NOTIFYCOMP_API_ORIGIN || 'https://api.notifycomp.com/api/graphql',
 });
 
 const wsLink = new GraphQLWsLink(
   createClient({
-    url: import.meta.env.VITE_NOTIFYCOMP_WS_ORIGIN || 'wss://admin.notifycomp.com/graphql',
+    url: import.meta.env.VITE_NOTIFYCOMP_WS_ORIGIN || 'wss://api.notifycomp.com/api/graphql',
   }),
 );
 

--- a/src/hooks/useAssignmentNotifications/index.ts
+++ b/src/hooks/useAssignmentNotifications/index.ts
@@ -1,0 +1,1 @@
+export * from './useAssignmentNotifications';

--- a/src/hooks/useAssignmentNotifications/useAssignmentNotifications.ts
+++ b/src/hooks/useAssignmentNotifications/useAssignmentNotifications.ts
@@ -1,0 +1,74 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  AssignmentNotificationStatus,
+  disableAssignmentNotifications,
+  enableAssignmentNotifications,
+  getAssignmentNotificationStatus,
+} from '@/lib/notifications/assignmentNotifications';
+
+interface UseAssignmentNotificationsParams {
+  competitions: ApiCompetition[];
+  user: User | null;
+}
+
+export function useAssignmentNotifications({
+  competitions,
+  user,
+}: UseAssignmentNotificationsParams) {
+  const [status, setStatus] = useState<AssignmentNotificationStatus>(
+    getAssignmentNotificationStatus,
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const watches = useMemo(
+    () =>
+      user
+        ? competitions.map((competition) => ({
+            competitionId: competition.id,
+            wcaUserId: user.id,
+          }))
+        : [],
+    [competitions, user],
+  );
+
+  const enable = useCallback(async () => {
+    setIsSaving(true);
+    setError(null);
+
+    try {
+      const nextStatus = await enableAssignmentNotifications(watches);
+      setStatus(nextStatus);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unable to enable assignment notifications.');
+      setStatus(getAssignmentNotificationStatus());
+    } finally {
+      setIsSaving(false);
+    }
+  }, [watches]);
+
+  const disable = useCallback(async () => {
+    setIsSaving(true);
+    setError(null);
+
+    try {
+      await disableAssignmentNotifications();
+      setStatus(getAssignmentNotificationStatus());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unable to disable assignment notifications.');
+    } finally {
+      setIsSaving(false);
+    }
+  }, []);
+
+  return {
+    canEnable: status === 'default' && watches.length > 0,
+    canDisable: status === 'granted',
+    enable,
+    disable,
+    error,
+    isSaving,
+    status,
+    watchCount: watches.length,
+  };
+}

--- a/src/hooks/useAssignmentNotifications/useAssignmentNotifications.ts
+++ b/src/hooks/useAssignmentNotifications/useAssignmentNotifications.ts
@@ -1,9 +1,10 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   AssignmentNotificationStatus,
   disableAssignmentNotifications,
   enableAssignmentNotifications,
   getAssignmentNotificationStatus,
+  isAssignmentNotificationsEnabled,
 } from '@/lib/notifications/assignmentNotifications';
 
 interface UseAssignmentNotificationsParams {
@@ -20,6 +21,12 @@ export function useAssignmentNotifications({
   );
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isEnabled, setIsEnabled] = useState(isAssignmentNotificationsEnabled);
+
+  useEffect(() => {
+    setStatus(getAssignmentNotificationStatus());
+    setIsEnabled(isAssignmentNotificationsEnabled());
+  }, [user]);
 
   const watches = useMemo(
     () =>
@@ -39,9 +46,11 @@ export function useAssignmentNotifications({
     try {
       const nextStatus = await enableAssignmentNotifications(watches);
       setStatus(nextStatus);
+      setIsEnabled(isAssignmentNotificationsEnabled());
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Unable to enable assignment notifications.');
       setStatus(getAssignmentNotificationStatus());
+      setIsEnabled(isAssignmentNotificationsEnabled());
     } finally {
       setIsSaving(false);
     }
@@ -54,16 +63,18 @@ export function useAssignmentNotifications({
     try {
       await disableAssignmentNotifications();
       setStatus(getAssignmentNotificationStatus());
+      setIsEnabled(isAssignmentNotificationsEnabled());
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Unable to disable assignment notifications.');
+      setIsEnabled(isAssignmentNotificationsEnabled());
     } finally {
       setIsSaving(false);
     }
   }, []);
 
   return {
-    canEnable: status === 'default' && watches.length > 0,
-    canDisable: status === 'granted',
+    canEnable: (status === 'default' || status === 'granted') && !isEnabled && watches.length > 0,
+    canDisable: status === 'granted' && isEnabled,
     enable,
     disable,
     error,

--- a/src/lib/notifications/assignmentNotifications.ts
+++ b/src/lib/notifications/assignmentNotifications.ts
@@ -1,7 +1,10 @@
-import { getLocalStorage } from '@/lib/localStorage';
+import { deleteLocalStorage, getLocalStorage, setLocalStorage } from '@/lib/localStorage';
 
-const NOTIFY_COMP_ORIGIN = import.meta.env.VITE_NOTIFY_COMP_ORIGIN ?? '';
+const NOTIFY_COMP_ORIGIN =
+  import.meta.env.VITE_NOTIFY_COMP_ORIGIN ?? 'https://api.notifycomp.com/api';
 const NOTIFY_COMP_TOKEN_URL = '/.netlify/functions/notify-comp-token';
+const ENABLED_STORAGE_KEY = 'assignmentNotifications.enabled';
+const SERVICE_WORKER_TIMEOUT_MS = 10000;
 
 interface PushSubscriptionJson {
   endpoint?: string;
@@ -16,9 +19,12 @@ export interface AssignmentNotificationWatch {
   wcaUserId: number;
 }
 
-export type AssignmentNotificationStatus = NotificationPermission | 'not-signed-in' | 'unsupported';
+export type AssignmentNotificationStatus = NotificationPermission | 'reauthorize' | 'unsupported';
 
 const notifyCompUrl = (path: string) => `${NOTIFY_COMP_ORIGIN}${path}`;
+
+export const isAssignmentNotificationsEnabled = () =>
+  getLocalStorage(ENABLED_STORAGE_KEY) === 'true';
 
 const getAccessToken = () => {
   const expiresAt = Number(getLocalStorage('expirationTime') ?? 0);
@@ -54,7 +60,7 @@ export const getAssignmentNotificationStatus = (): AssignmentNotificationStatus 
   }
 
   if (!getAccessToken()) {
-    return 'not-signed-in';
+    return 'reauthorize';
   }
 
   return Notification.permission;
@@ -72,10 +78,21 @@ export const requestAssignmentNotificationPermission = async () => {
   return await Notification.requestPermission();
 };
 
+const readErrorMessage = async (response: Response) => {
+  const text = await response.text();
+
+  try {
+    const payload = JSON.parse(text) as { message?: string };
+    return payload.message || text;
+  } catch {
+    return text;
+  }
+};
+
 const fetchNotifyCompToken = async () => {
   const accessToken = getAccessToken();
   if (!accessToken) {
-    throw new Error('Sign in with WCA to enable assignment notifications.');
+    throw new Error('Refresh your WCA authorization to enable assignment notifications.');
   }
 
   const response = await fetch(NOTIFY_COMP_TOKEN_URL, {
@@ -87,7 +104,7 @@ const fetchNotifyCompToken = async () => {
   });
 
   if (!response.ok) {
-    throw new Error(await response.text());
+    throw new Error(await readErrorMessage(response));
   }
 
   const payload = (await response.json()) as { token?: string };
@@ -102,7 +119,7 @@ const fetchVapidPublicKey = async () => {
   const response = await fetch(notifyCompUrl('/v0/external/push/vapid-public-key'));
 
   if (!response.ok) {
-    throw new Error(await response.text());
+    throw new Error(await readErrorMessage(response));
   }
 
   const payload = (await response.json()) as { publicKey?: string };
@@ -113,8 +130,27 @@ const fetchVapidPublicKey = async () => {
   return payload.publicKey;
 };
 
+const withTimeout = async <T>(promise: Promise<T>, message: string) =>
+  await Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      window.setTimeout(() => reject(new Error(message)), SERVICE_WORKER_TIMEOUT_MS);
+    }),
+  ]);
+
+const getServiceWorkerRegistration = async () => {
+  if (import.meta.env.DEV) {
+    return await navigator.serviceWorker.register('/notification-sw.js');
+  }
+
+  return await withTimeout(
+    navigator.serviceWorker.ready,
+    'Notification service worker was not ready. Refresh the page and try again.',
+  );
+};
+
 const getPushSubscription = async () => {
-  const registration = await navigator.serviceWorker.ready;
+  const registration = await getServiceWorkerRegistration();
   const existing = await registration.pushManager.getSubscription();
 
   if (existing) {
@@ -133,7 +169,8 @@ export const enableAssignmentNotifications = async (watches: AssignmentNotificat
     return permission;
   }
 
-  const [token, subscription] = await Promise.all([fetchNotifyCompToken(), getPushSubscription()]);
+  const token = await fetchNotifyCompToken();
+  const subscription = await getPushSubscription();
   const payload = subscription.toJSON() as PushSubscriptionJson;
 
   if (!payload.endpoint || !payload.keys?.p256dh || !payload.keys.auth) {
@@ -155,17 +192,20 @@ export const enableAssignmentNotifications = async (watches: AssignmentNotificat
   });
 
   if (!response.ok) {
-    throw new Error(await response.text());
+    deleteLocalStorage(ENABLED_STORAGE_KEY);
+    throw new Error(await readErrorMessage(response));
   }
 
+  setLocalStorage(ENABLED_STORAGE_KEY, 'true');
   return permission;
 };
 
 export const disableAssignmentNotifications = async () => {
-  const registration = await navigator.serviceWorker.ready;
+  const registration = await getServiceWorkerRegistration();
   const subscription = await registration.pushManager.getSubscription();
 
   if (!subscription) {
+    deleteLocalStorage(ENABLED_STORAGE_KEY);
     return;
   }
 
@@ -184,4 +224,5 @@ export const disableAssignmentNotifications = async () => {
   }
 
   await subscription.unsubscribe();
+  deleteLocalStorage(ENABLED_STORAGE_KEY);
 };

--- a/src/lib/notifications/assignmentNotifications.ts
+++ b/src/lib/notifications/assignmentNotifications.ts
@@ -1,0 +1,187 @@
+import { getLocalStorage } from '@/lib/localStorage';
+
+const NOTIFY_COMP_ORIGIN = import.meta.env.VITE_NOTIFY_COMP_ORIGIN ?? '';
+const NOTIFY_COMP_TOKEN_URL = '/.netlify/functions/notify-comp-token';
+
+interface PushSubscriptionJson {
+  endpoint?: string;
+  keys?: {
+    p256dh?: string;
+    auth?: string;
+  };
+}
+
+export interface AssignmentNotificationWatch {
+  competitionId: string;
+  wcaUserId: number;
+}
+
+export type AssignmentNotificationStatus = NotificationPermission | 'not-signed-in' | 'unsupported';
+
+const notifyCompUrl = (path: string) => `${NOTIFY_COMP_ORIGIN}${path}`;
+
+const getAccessToken = () => {
+  const expiresAt = Number(getLocalStorage('expirationTime') ?? 0);
+  const accessToken = getLocalStorage('accessToken');
+
+  if (!accessToken || !expiresAt || expiresAt <= Date.now()) {
+    return null;
+  }
+
+  return accessToken;
+};
+
+const toUint8Array = (base64: string) => {
+  const padding = '='.repeat((4 - (base64.length % 4)) % 4);
+  const normalized = `${base64}${padding}`.replace(/-/g, '+').replace(/_/g, '/');
+  const raw = window.atob(normalized);
+  const output = new Uint8Array(raw.length);
+
+  for (let index = 0; index < raw.length; index += 1) {
+    output[index] = raw.charCodeAt(index);
+  }
+
+  return output;
+};
+
+export const getAssignmentNotificationStatus = (): AssignmentNotificationStatus => {
+  if (
+    !('Notification' in window) ||
+    !('serviceWorker' in navigator) ||
+    !('PushManager' in window)
+  ) {
+    return 'unsupported';
+  }
+
+  if (!getAccessToken()) {
+    return 'not-signed-in';
+  }
+
+  return Notification.permission;
+};
+
+export const requestAssignmentNotificationPermission = async () => {
+  if (!('Notification' in window)) {
+    return 'unsupported' as const;
+  }
+
+  if (Notification.permission === 'granted') {
+    return 'granted' as const;
+  }
+
+  return await Notification.requestPermission();
+};
+
+const fetchNotifyCompToken = async () => {
+  const accessToken = getAccessToken();
+  if (!accessToken) {
+    throw new Error('Sign in with WCA to enable assignment notifications.');
+  }
+
+  const response = await fetch(NOTIFY_COMP_TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ accessToken }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+
+  const payload = (await response.json()) as { token?: string };
+  if (!payload.token) {
+    throw new Error('Notification token response was missing a token.');
+  }
+
+  return payload.token;
+};
+
+const fetchVapidPublicKey = async () => {
+  const response = await fetch(notifyCompUrl('/v0/external/push/vapid-public-key'));
+
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+
+  const payload = (await response.json()) as { publicKey?: string };
+  if (!payload.publicKey) {
+    throw new Error('NotifyComp did not return a VAPID public key.');
+  }
+
+  return payload.publicKey;
+};
+
+const getPushSubscription = async () => {
+  const registration = await navigator.serviceWorker.ready;
+  const existing = await registration.pushManager.getSubscription();
+
+  if (existing) {
+    return existing;
+  }
+
+  return await registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: toUint8Array(await fetchVapidPublicKey()),
+  });
+};
+
+export const enableAssignmentNotifications = async (watches: AssignmentNotificationWatch[]) => {
+  const permission = await requestAssignmentNotificationPermission();
+  if (permission !== 'granted') {
+    return permission;
+  }
+
+  const [token, subscription] = await Promise.all([fetchNotifyCompToken(), getPushSubscription()]);
+  const payload = subscription.toJSON() as PushSubscriptionJson;
+
+  if (!payload.endpoint || !payload.keys?.p256dh || !payload.keys.auth) {
+    throw new Error('Browser push subscription is missing required keys.');
+  }
+
+  const response = await fetch(notifyCompUrl('/v0/external/push/subscriptions'), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      endpoint: payload.endpoint,
+      p256dh: payload.keys.p256dh,
+      auth: payload.keys.auth,
+      watches,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+
+  return permission;
+};
+
+export const disableAssignmentNotifications = async () => {
+  const registration = await navigator.serviceWorker.ready;
+  const subscription = await registration.pushManager.getSubscription();
+
+  if (!subscription) {
+    return;
+  }
+
+  const token = await fetchNotifyCompToken();
+  const payload = subscription.toJSON() as PushSubscriptionJson;
+
+  if (payload.endpoint) {
+    await fetch(notifyCompUrl('/v0/external/push/subscriptions'), {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ endpoint: payload.endpoint }),
+    });
+  }
+
+  await subscription.unsubscribe();
+};

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -1,8 +1,17 @@
-import { Container } from '@/components';
+import { Button, Container } from '@/components';
+import { useMyCompetitionsQuery } from '@/containers/MyCompetitions/MyCompetitions.query';
+import { useAssignmentNotifications } from '@/hooks/useAssignmentNotifications';
+import { useAuth } from '@/providers/AuthProvider';
 import { Theme, useUserSettings } from '@/providers/UserSettingsProvider';
 
 export default function Settings() {
   const { theme, setTheme } = useUserSettings();
+  const { user, signIn } = useAuth();
+  const { competitions, isLoading } = useMyCompetitionsQuery(user?.id);
+  const notifications = useAssignmentNotifications({
+    competitions,
+    user,
+  });
 
   const themeOptions: { value: Theme; label: string; description: string }[] = [
     { value: 'light', label: 'Light', description: 'Always use light theme' },
@@ -12,30 +21,94 @@ export default function Settings() {
 
   return (
     <Container className="px-4 py-8">
-      <h1 className="mb-6 type-display">Settings</h1>
+      <div className="space-y-6">
+        <h1 className="type-display">Settings</h1>
 
-      <div className="p-6 bg-panel rounded-lg shadow-md shadow-tertiary-dark">
-        <h2 className="mb-4 type-heading">Appearance</h2>
+        <div className="space-y-4 p-6 bg-panel rounded-lg shadow-md shadow-tertiary-dark">
+          <h2 className="type-heading">Appearance</h2>
 
-        <div className="space-y-3">
-          <label className="block mb-2 type-label">Theme</label>
-          {themeOptions.map((option) => (
-            <div key={option.value} className="flex items-start">
-              <input
-                type="radio"
-                id={`theme-${option.value}`}
-                name="theme"
-                value={option.value}
-                checked={theme === option.value}
-                onChange={() => setTheme(option.value)}
-                className="radio mt-1"
-              />
-              <label htmlFor={`theme-${option.value}`} className="flex-1 ml-3 cursor-pointer">
-                <span className="block type-label">{option.label}</span>
-                <span className="block type-meta">{option.description}</span>
-              </label>
+          <div className="space-y-3">
+            <label className="block type-label">Theme</label>
+            {themeOptions.map((option) => (
+              <div key={option.value} className="flex items-start gap-2">
+                <input
+                  type="radio"
+                  id={`theme-${option.value}`}
+                  name="theme"
+                  value={option.value}
+                  checked={theme === option.value}
+                  onChange={() => setTheme(option.value)}
+                  className="radio"
+                />
+                <label htmlFor={`theme-${option.value}`} className="flex-1 cursor-pointer">
+                  <span className="block type-label">{option.label}</span>
+                  <span className="block type-meta">{option.description}</span>
+                </label>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-4 p-6 bg-panel rounded-lg shadow-md shadow-tertiary-dark">
+          <div className="space-y-2">
+            <h2 className="type-heading">Assignment notifications</h2>
+            <p className="type-body-sm text-subtle">
+              Get push notifications when your assignments change for upcoming and ongoing
+              competitions.
+            </p>
+            <p className="type-meta">
+              Watching {notifications.watchCount} competition
+              {notifications.watchCount === 1 ? '' : 's'}.
+            </p>
+          </div>
+
+          {!user && (
+            <Button type="button" onClick={signIn}>
+              Sign in with WCA
+            </Button>
+          )}
+
+          {user && notifications.status === 'unsupported' && (
+            <p className="type-meta">This browser does not support push notifications.</p>
+          )}
+
+          {user && notifications.status === 'not-signed-in' && (
+            <div className="space-y-2">
+              <p className="type-meta">Sign in with WCA again to enable notifications.</p>
+              <Button type="button" onClick={signIn}>
+                Sign in with WCA
+              </Button>
             </div>
-          ))}
+          )}
+
+          {user && notifications.canEnable && (
+            <Button
+              type="button"
+              disabled={notifications.isSaving || isLoading}
+              onClick={() => {
+                void notifications.enable();
+              }}>
+              {notifications.isSaving ? 'Enabling...' : 'Enable assignment notifications'}
+            </Button>
+          )}
+
+          {user && notifications.canDisable && (
+            <Button
+              type="button"
+              variant="gray"
+              disabled={notifications.isSaving}
+              onClick={() => {
+                void notifications.disable();
+              }}>
+              {notifications.isSaving ? 'Disabling...' : 'Disable assignment notifications'}
+            </Button>
+          )}
+
+          {user && notifications.status === 'denied' && (
+            <p className="type-meta">Notifications are blocked in your browser settings.</p>
+          )}
+
+          {notifications.error && <p className="type-meta text-red-500">{notifications.error}</p>}
         </div>
       </div>
     </Container>

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -72,11 +72,11 @@ export default function Settings() {
             <p className="type-meta">This browser does not support push notifications.</p>
           )}
 
-          {user && notifications.status === 'not-signed-in' && (
+          {user && notifications.status === 'reauthorize' && (
             <div className="space-y-2">
-              <p className="type-meta">Sign in with WCA again to enable notifications.</p>
+              <p className="type-meta">Refresh your WCA authorization to enable notifications.</p>
               <Button type="button" onClick={signIn}>
-                Sign in with WCA
+                Continue with WCA
               </Button>
             </div>
           )}

--- a/src/providers/AuthProvider/AuthProvider.tsx
+++ b/src/providers/AuthProvider/AuthProvider.tsx
@@ -85,6 +85,11 @@ export function AuthProvider({ children }: PropsWithChildren) {
 
     fetchMe(accessToken)
       .then(({ me, ongoing_competitions, upcoming_competitions }) => {
+        setLocalStorage('accessToken', accessToken);
+        setLocalStorage(
+          'expirationTime',
+          String(Date.now() + Number(hashParams.get('expires_in') ?? 0) * 1000),
+        );
         setUserAndSave(me);
         queryClient.setQueryData(['userCompetitions'], {
           ongoing_competitions,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,4 +6,6 @@ declare const __GIT_TAG__: string;
 
 interface ImportMetaEnv {
   readonly VITE_NOTIFY_COMP_ORIGIN?: string;
+  readonly VITE_NOTIFYCOMP_API_ORIGIN?: string;
+  readonly VITE_NOTIFYCOMP_WS_ORIGIN?: string;
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,3 +3,7 @@
 
 declare const __GIT_COMMIT__: string;
 declare const __GIT_TAG__: string;
+
+interface ImportMetaEnv {
+  readonly VITE_NOTIFY_COMP_ORIGIN?: string;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,9 @@ export default defineConfig({
     ViteYaml(),
     VitePWA({
       registerType: 'autoUpdate',
+      workbox: {
+        importScripts: ['notification-sw.js'],
+      },
     }),
   ],
   build: {


### PR DESCRIPTION
## Summary
- add a same-origin Netlify token function that verifies the current WCA access token and mints short-lived NotifyComp JWTs
- add browser Push API registration, NotifyComp subscription sync, and assignment notification controls in Settings
- import a push notification handler into the generated PWA service worker

## Configuration
- set COMPETITION_GROUPS_JWT_SECRET on this app and the matching NotifyComp service
- optionally set COMPETITION_GROUPS_JWT_ISSUER, COMPETITION_GROUPS_JWT_AUDIENCE, WCA_ORIGIN, and VITE_NOTIFY_COMP_ORIGIN

## Validation
- yarn check:type
- yarn lint
- yarn build
- pre-push hook: lint, typecheck, jest