### PR TITLE
Render DNF and DNS result sentinels

### DIFF
--- a/src/lib/results.test.ts
+++ b/src/lib/results.test.ts
@@ -1,0 +1,18 @@
+import { renderResultByEventId } from './results';
+
+describe('renderResultByEventId', () => {
+  it('renders DNF before event-specific formatting', () => {
+    expect(renderResultByEventId('333', 'single', -1)).toBe('DNF');
+    expect(renderResultByEventId('333fm', 'average', -1)).toBe('DNF');
+  });
+
+  it('renders DNS before event-specific formatting', () => {
+    expect(renderResultByEventId('333', 'single', -2)).toBe('DNS');
+    expect(renderResultByEventId('333mbf', 'single', -2)).toBe('DNS');
+  });
+
+  it('keeps normal result formatting unchanged', () => {
+    expect(renderResultByEventId('333', 'single', 1234)).toBe('12.34');
+    expect(renderResultByEventId('333fm', 'average', 2533)).toBe('25.33');
+  });
+});

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -13,6 +13,14 @@ export const renderResultByEventId = (
   rankingType: RankingType,
   result: AttemptResult,
 ) => {
+  if (result === -1) {
+    return 'DNF';
+  }
+
+  if (result === -2) {
+    return 'DNS';
+  }
+
   if (eventId === '333fm') {
     return rankingType === 'average' ? ((result as number) / 100).toFixed(2).toString() : result;
   }


### PR DESCRIPTION
## Summary

- render WCA result sentinel `-1` as `DNF`
- render WCA result sentinel `-2` as `DNS`
- handle both values before centisecond, FMC, or Multi-Blind formatting
- add focused regression tests for the two statuses and unchanged normal formatting

Fixes #86

## Validation

- Focused Jest coverage added in `src/lib/results.test.ts`
- GitHub Actions pending